### PR TITLE
Make DiagnosticContextCollector thread-safe

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Serilog.Extensions.Hosting [![Build status](https://ci.appveyor.com/api/projects/status/ue4s7htjwj88fulh?svg=true)](https://ci.appveyor.com/project/serilog/serilog-extensions-hosting) [![NuGet Version](http://img.shields.io/nuget/v/Serilog.Extensions.Hosting.svg?style=flat)](https://www.nuget.org/packages/Serilog.Extensions.Hosting/) 
 
-Serilog logging for Microsoft.Extensions.Hosting . This package routes Microsoft.Extensions.Hosting log messages through Serilog, so you can get information about the framework's internal operations logged to the same Serilog sinks as your application events.
+Serilog logging for _Microsoft.Extensions.Hosting_. This package routes framework log messages through Serilog, so you can get information about the framework's internal operations written to the same Serilog sinks as your application events.
 
 ### Instructions
 

--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/AmbientDiagnosticContextCollector.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/AmbientDiagnosticContextCollector.cs
@@ -1,4 +1,18 @@
-﻿using System;
+﻿// Copyright 2019 Serilog Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+using System;
 using System.Threading;
 
 namespace Serilog.Extensions.Hosting

--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContextCollector.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContextCollector.cs
@@ -11,7 +11,7 @@ namespace Serilog.Extensions.Hosting
     {
         readonly IDisposable _chainedDisposable;
         readonly object _propertiesLock = new object();
-        List<LogEventProperty> _properties = new List<LogEventProperty>();
+        Dictionary<string, LogEventProperty> _properties = new Dictionary<string, LogEventProperty>();
 
         /// <summary>
         /// Construct a <see cref="DiagnosticContextCollector"/>.
@@ -34,17 +34,7 @@ namespace Serilog.Extensions.Hosting
             lock (_propertiesLock)
             {
                 if (_properties == null) return;
-
-                for (var i = 0; i < _properties.Count; ++i)
-                {
-                    if (_properties[i].Name == property.Name)
-                    {
-                        _properties[i] = property;
-                        return;
-                    }
-                }
-
-                _properties.Add(property);
+                _properties[property.Name] = property;
             }
         }
 
@@ -55,11 +45,11 @@ namespace Serilog.Extensions.Hosting
         /// </summary>
         /// <param name="properties">The collected properties, or null if no collection is active.</param>
         /// <returns>True if properties could be collected.</returns>
-        public bool TryComplete(out List<LogEventProperty> properties)
+        public bool TryComplete(out IEnumerable<LogEventProperty> properties)
         {
             lock (_propertiesLock)
             {
-                properties = _properties;
+                properties = _properties?.Values;
                 _properties = null;
                 Dispose();
                 return properties != null;

--- a/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
+++ b/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
@@ -20,12 +20,13 @@ namespace Serilog
     public interface IDiagnosticContext
     {
         /// <summary>
-        /// Add the specified property to the request's diagnostic payload.
+        /// Set the specified property on the current diagnostic context. The property will be collected
+        /// and attached to the event emitted at the completion of the context.
         /// </summary>
         /// <param name="propertyName">The name of the property. Must be non-empty.</param>
         /// <param name="value">The property value.</param>
         /// <param name="destructureObjects">If true, the value will be serialized as structured
         /// data if possible; if false, the object will be recorded as a scalar or simple array.</param>
-        void Add(string propertyName, object value, bool destructureObjects = false); 
+        void Set(string propertyName, object value, bool destructureObjects = false); 
     }
 }

--- a/test/Serilog.Extensions.Hosting.Tests/DiagnosticContextTests.cs
+++ b/test/Serilog.Extensions.Hosting.Tests/DiagnosticContextTests.cs
@@ -1,17 +1,21 @@
 ﻿using System;
+using System.Linq;
 using System.Threading.Tasks;
+using Serilog.Events;
 using Serilog.Extensions.Hosting.Tests.Support;
 using Xunit;
+
+// ReSharper disable PossibleNullReferenceException
 
 namespace Serilog.Extensions.Hosting.Tests
 {
     public class DiagnosticContextTests
     {
         [Fact]
-        public void AddIsSafeWhenNoContextIsActive()
+        public void SetIsSafeWhenNoContextIsActive()
         {
             var dc = new DiagnosticContext(Some.Logger());
-            dc.Add(Some.String("name"), Some.Int32());
+            dc.Set(Some.String("name"), Some.Int32());
         }
 
         [Fact]
@@ -20,19 +24,34 @@ namespace Serilog.Extensions.Hosting.Tests
             var dc = new DiagnosticContext(Some.Logger());
 
             var collector = dc.BeginCollection();
-            dc.Add(Some.String("name"), Some.Int32());
+            dc.Set(Some.String("first"), Some.Int32());
             await Task.Delay(TimeSpan.FromMilliseconds(10));
-            dc.Add(Some.String("name"), Some.Int32());
+            dc.Set(Some.String("second"), Some.Int32());
 
             Assert.True(collector.TryComplete(out var properties));
-            Assert.Equal(2, properties.Count);
+            Assert.Equal(2, properties.Count());
 
             Assert.False(collector.TryComplete(out _));
 
             collector.Dispose();
 
-            dc.Add(Some.String("name"), Some.Int32());
+            dc.Set(Some.String("third"), Some.Int32());
             Assert.False(collector.TryComplete(out _));
+        }
+
+        [Fact]
+        public void ExistingPropertiesCanBeUpdated()
+        {
+            var dc = new DiagnosticContext(Some.Logger());
+
+            var collector = dc.BeginCollection();
+            dc.Set("name", 10);
+            dc.Set("name", 20);
+
+            Assert.True(collector.TryComplete(out var properties));
+            var prop = Assert.Single(properties);
+            var scalar = Assert.IsType<ScalarValue>(prop.Value);
+            Assert.Equal(20, scalar.Value);
         }
     }
 }


### PR DESCRIPTION
Looking at this again, it would be too easy to violate the single-threadedness of `DiagnosticContextCollector` in the current design - there's no indication in the API of `IDiagnosticContext` that there are any constraints on how its called.

This PR introduces a simple mutex to make `DiagnosticContextCollector` thread-safe. There's a possibility this could be done lock-free, but that's probably fine to punt for a future iteration.

After the PR, the example in https://github.com/serilog/serilog-extensions-hosting/pull/9#issuecomment-505198781 will be correct/safe:

```csharp
var collector = _diagnosticContext.BeginCollection();
var task = SomeMethodAsync();
collector.TryComplete(...);
```