### PR TITLE
Update to Serilog.Extensions.Logging 3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Serilog logging for _Microsoft.Extensions.Hosting_. This package routes framework log messages through Serilog, so you can get information about the framework's internal operations written to the same Serilog sinks as your application events.
 
+**ASP.NET Core** applications should consider [using _Serilog.AspNetCore_ instead](https://github.com/serilog/serilog-aspnetcore), which bundles this package and includes other ASP.NET Core-specific features.
+
 ### Instructions
 
 **First**, install the _Serilog.Extensions.Hosting_ [NuGet package](https://www.nuget.org/packages/Serilog.Extensions.Hosting) into your app. You will need a way to view the log messages - _Serilog.Sinks.Console_ writes these to the console; there are [many more sinks available](https://www.nuget.org/packages?q=Tags%3A%22serilog%22) on NuGet.
@@ -63,7 +65,7 @@ That's it! You will see log output like:
 [22:10:39 INF] The current time is: 12/05/2018 10:10:39 +00:00
 ```
 
-A more complete example, showing _appsettings.json_ configuration, can be found in [the sample project here](https://github.com/serilog/serilog-hostinh/tree/dev/samples/SimpleServiceSample).
+A more complete example, showing _appsettings.json_ configuration, can be found in [the sample project here](https://github.com/serilog/serilog-hosting/tree/dev/samples/SimpleServiceSample).
 
 ### Using the package
 
@@ -78,39 +80,11 @@ You can alternatively configure Serilog using a delegate as shown below:
 ```csharp
     // dotnet add package Serilog.Settings.Configuration
     .UseSerilog((hostingContext, loggerConfiguration) => loggerConfiguration
-	.ReadFrom.Configuration(hostingContext.Configuration)
-	.Enrich.FromLogContext()
-	.WriteTo.Console())
+        .ReadFrom.Configuration(hostingContext.Configuration)
+        .Enrich.FromLogContext()
+        .WriteTo.Console())
 ```
 
 This has the advantage of making the `hostingContext`'s `Configuration` object available for configuration of the logger, but at the expense of recording `Exception`s raised earlier in program startup.
 
 If this method is used, `Log.Logger` is assigned implicitly, and closed when the app is shut down.
-
-### Writing to the Azure Diagnostics Log Stream
-
-The Azure Diagnostic Log Stream ships events from any files in the `D:\home\LogFiles\` folder. To enable this for your app, first install the _Serilog.Sinks.File_ package:
-
-```powershell
-Install-Package Serilog.Sinks.File
-```
-
-Then add a file sink to your `LoggerConfiguration`, taking care to set the `shared` and `flushToDiskInterval` parameters:
-
-```csharp
-    public static int Main(string[] args)
-    {
-        Log.Logger = new LoggerConfiguration()
-            .MinimumLevel.Debug()
-            .MinimumLevel.Override("Microsoft", LogEventLevel.Information)
-            .Enrich.FromLogContext()
-            .WriteTo.Console()
-	    // Add this line:
-	    .WriteTo.File(
-	    	@"D:\home\LogFiles\Application\myapp.txt",
-		fileSizeLimitBytes: 1_000_000,
-		rollOnFileSizeLimit: true,
-		shared: true,
-		flushToDiskInterval: TimeSpan.FromSeconds(1))
-            .CreateLogger();
-```

--- a/samples/SimpleServiceSample/SimpleServiceSample.csproj
+++ b/samples/SimpleServiceSample/SimpleServiceSample.csproj
@@ -13,12 +13,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.1.0-rc1-final" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="2.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
+++ b/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <Description>Serilog support for .NET Core logging in hosted services</Description>
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />

--- a/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
+++ b/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
@@ -24,7 +24,7 @@
 
   <ItemGroup>
     <PackageReference Include="Serilog" Version="2.8.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0-*" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.1.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="2.1.0" />

--- a/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
+++ b/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.1.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
Also

 * updates other non-shipping dependencies
 * reduces README duplication
 * points ASP.NET Core users to _Serilog.AspNetCore_, which now includes ASP.NET Core-specific features on top of this package