### PR TITLE
Bring sample app more in line with Microsoft docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,7 +46,6 @@ dlldata.c
 project.lock.json
 project.fragment.lock.json
 artifacts/
-**/Properties/launchSettings.json
 
 *_i.c
 *_p.c

--- a/samples/SimpleServiceSample/PrintTimeService.cs
+++ b/samples/SimpleServiceSample/PrintTimeService.cs
@@ -6,39 +6,22 @@ using Microsoft.Extensions.Logging;
 
 namespace SimpleServiceSample
 {
-    public class PrintTimeService : IHostedService, IDisposable
+    public class PrintTimeService : BackgroundService
     {
         private readonly ILogger _logger;
-        private Timer _timer;
 
         public PrintTimeService(ILogger<PrintTimeService> logger)
         {
             _logger = logger;
         }
 
-        public Task StartAsync(CancellationToken cancellationToken)
+        protected override async Task ExecuteAsync(CancellationToken stoppingToken)
         {
-            _timer = new Timer(DoWork, null, TimeSpan.Zero,
-              TimeSpan.FromSeconds(5));
-
-            return Task.CompletedTask;
-        }
-
-        private void DoWork(object state)
-        {
-            _logger.LogInformation($"The current time is: {DateTimeOffset.UtcNow}");
-        }
-
-        public Task StopAsync(CancellationToken cancellationToken)
-        {
-            _timer?.Change(Timeout.Infinite, 0);
-
-            return Task.CompletedTask;
-        }
-
-        public void Dispose()
-        {
-            _timer?.Dispose();
+            while (!stoppingToken.IsCancellationRequested)
+            {
+                _logger.LogInformation("The current time is: {CurrentTime}", DateTimeOffset.UtcNow);
+                await Task.Delay(TimeSpan.FromSeconds(5), stoppingToken);
+            }
         }
     }
 }

--- a/samples/SimpleServiceSample/Program.cs
+++ b/samples/SimpleServiceSample/Program.cs
@@ -30,9 +30,7 @@ namespace SimpleServiceSample
             try
             {
                 Log.Information("Getting the motors running...");
-
-                BuildHost(args).Run();
-
+                CreateHostBuilder(args).Build().Run();
                 return 0;
             }
             catch (Exception ex)
@@ -46,11 +44,9 @@ namespace SimpleServiceSample
             }
         }
 
-        public static IHost BuildHost(string[] args) =>
-            new HostBuilder()
-                .ConfigureHostConfiguration(BuildConfiguration)
-                .ConfigureServices(services => services.AddSingleton<IHostedService, PrintTimeService>())
-                .UseSerilog()
-                .Build();
+        public static IHostBuilder CreateHostBuilder(string[] args) =>
+            Host.CreateDefaultBuilder(args)
+                .ConfigureServices(services => services.AddHostedService<PrintTimeService>())
+                .UseSerilog();
     }
 }

--- a/samples/SimpleServiceSample/Properties/launchSettings.json
+++ b/samples/SimpleServiceSample/Properties/launchSettings.json
@@ -1,0 +1,10 @@
+{
+  "profiles": {
+    "SimpleServiceSample": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    }
+  }
+}

--- a/samples/SimpleServiceSample/SimpleServiceSample.csproj
+++ b/samples/SimpleServiceSample/SimpleServiceSample.csproj
@@ -1,22 +1,15 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+  
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
-    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
-  <ItemGroup>
-    <Content Include="appsettings.json" CopyToOutputDirectory="PreserveNewest" />
-    <Content Include="appsettings.Development.json" CopyToOutputDirectory="PreserveNewest" DependentUpon="appsettings.json" />
-  </ItemGroup>
-
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="2.2.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
   </ItemGroup>


### PR DESCRIPTION
This PR aims to bring the included `SimpleServiceSample` better in line with the samples given in the Microsoft docs. I think we should strive to keep as close as possible to the archetypical samples given by Microsoft. That makes the typical setup of a hosted service/background service better recognizable, and shows better what is typical to setting up Serilog.

This PR:
- Updates the sample project to use the `Microsoft.NET.Sdk.Worker` SDK. This is the default SDK when creating a new project from the template 'Worker Service'.
- Updates the targeting to `netcore3.1`.
- Simplifies the sample service by deriving from `BackgroundService` instead of implementing `IHostedService` directly. This leads to a simpler example (better focus on the mechanics of setting up and configuring Serilog). As there are some caveats with implementing `IHostedService` directly, devs new to worker services are better of starting from `BackgroundService`.
- No longer ignores tracking of `launchSettings.json`.