### PR TITLE
Pin .NET Core SDK to 3.1.* feature band and patch level

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,5 +1,7 @@
 {
   "sdk": {
-    "version": "3.1.201"
+    "allowPrerelease": false,
+    "version": "3.1.100",
+    "rollForward": "latestFeature"
   }
 }


### PR DESCRIPTION
Update the pinned .NET Core SDK to the `3.1.3??` feature band. Do not allow prereleases.