### PR TITLE
Re-enable .NET Framework (.NET Standard 2.0) support by excluding CreateBootstrapLogger()/ReloadableLogger on that platform

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "3.1.100",
+    "version": "5.0.102",
     "rollForward": "latestFeature"
   }
 }

--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/CachingReloadableLogger.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/CachingReloadableLogger.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !NO_RELOADABLE_LOGGER
+
 using System;
 using System.Collections.Generic;
 using System.Threading;
@@ -517,3 +519,5 @@ namespace Serilog.Extensions.Hosting
         }
     }
 }
+
+#endif

--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/ReloadableLogger.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/ReloadableLogger.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !NO_RELOADABLE_LOGGER
+
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
@@ -667,3 +669,5 @@ namespace Serilog.Extensions.Hosting
         }
     }
 }
+
+#endif

--- a/src/Serilog.Extensions.Hosting/LoggerConfigurationExtensions.cs
+++ b/src/Serilog.Extensions.Hosting/LoggerConfigurationExtensions.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !NO_RELOADABLE_LOGGER
+
 using Microsoft.Extensions.Hosting;
 using Serilog.Extensions.Hosting;
 using System;
@@ -38,3 +40,5 @@ namespace Serilog
         }
     }
 }
+
+#endif

--- a/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
+++ b/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <Description>Serilog support for .NET Core logging in hosted services</Description>
-    <VersionPrefix>4.0.1</VersionPrefix>
+    <VersionPrefix>4.1.0</VersionPrefix>
     <Authors>Microsoft;Serilog Contributors</Authors>
-    <TargetFramework>netstandard2.1</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
+    <LangVersion>8</LangVersion>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Serilog.Extensions.Hosting</AssemblyName>
@@ -20,6 +21,10 @@
     <RepositoryType>git</RepositoryType>
     <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
     <RootNamespace>Serilog</RootNamespace>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>

--- a/test/Serilog.Extensions.Hosting.Tests/ReloadableLoggerTests.cs
+++ b/test/Serilog.Extensions.Hosting.Tests/ReloadableLoggerTests.cs
@@ -1,4 +1,6 @@
-﻿using Xunit;
+﻿#if !NO_RELOADABLE_LOGGER
+
+using Xunit;
 
 namespace Serilog.Extensions.Hosting.Tests
 {
@@ -20,3 +22,5 @@ namespace Serilog.Extensions.Hosting.Tests
         }
     }
 }
+
+#endif

--- a/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
+++ b/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFrameworks>netcoreapp3.1;net5.0;net4.8</TargetFrameworks>
     <AssemblyName>Serilog.Extensions.Hosting.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -10,6 +10,10 @@
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net4.8' ">
+    <DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
+  </PropertyGroup>
+  
   <ItemGroup>
     <ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
   </ItemGroup>


### PR DESCRIPTION
The conditional compilation is awful, but less awful than the support burden that will come from dropping .NET Framework.

I'll push this through shortly unless anyone spots something I've missed :-)

Fixes #33

