### PR TITLE
Fix minimum level overrides in reloadable loggers

### DIFF
--- a/test/Serilog.Extensions.Hosting.Tests/LoggerSettingsConfigurationExtensionsTests.cs
+++ b/test/Serilog.Extensions.Hosting.Tests/LoggerSettingsConfigurationExtensionsTests.cs
@@ -1,5 +1,7 @@
-﻿using Microsoft.Extensions.DependencyInjection;
+﻿using System.Collections.Generic;
+using Microsoft.Extensions.DependencyInjection;
 using Serilog.Core;
+using Serilog.Events;
 using Serilog.Extensions.Hosting.Tests.Support;
 using Xunit;
 
@@ -10,10 +12,10 @@ namespace Serilog.Extensions.Hosting.Tests
         [Fact]
         public void SinksAreInjectedFromTheServiceProvider()
         {
-            var sink = new SerilogSink();
+            var emittedEvents = new List<LogEvent>();
             
             var serviceCollection = new ServiceCollection();
-            serviceCollection.AddSingleton<ILogEventSink>(sink);
+            serviceCollection.AddSingleton<ILogEventSink>(new ListSink(emittedEvents));
             using var services = serviceCollection.BuildServiceProvider();
 
             using var logger = new LoggerConfiguration()
@@ -22,7 +24,7 @@ namespace Serilog.Extensions.Hosting.Tests
             
             logger.Information("Hello, world!");
             
-            var evt = Assert.Single(sink.Writes);
+            var evt = Assert.Single(emittedEvents);
             Assert.Equal("Hello, world!", evt!.MessageTemplate.Text);
         }
     }

--- a/test/Serilog.Extensions.Hosting.Tests/Support/ListSink.cs
+++ b/test/Serilog.Extensions.Hosting.Tests/Support/ListSink.cs
@@ -7,13 +7,18 @@ using Serilog.Events;
 
 namespace Serilog.Extensions.Hosting.Tests.Support
 {
-    public class SerilogSink : ILogEventSink
+    public class ListSink : ILogEventSink
     {
-        public List<LogEvent> Writes { get; set; } = new List<LogEvent>();
+        readonly List<LogEvent> _list;
+
+        public ListSink(List<LogEvent> list)
+        {
+            _list = list;
+        }
 
         public void Emit(LogEvent logEvent)
         {
-            Writes.Add(logEvent);
+            _list.Add(logEvent);
         }
     }
 }


### PR DESCRIPTION
Ensures that wrapped loggers have a chance to observe the value of SourceContext properties. Previous behavior was to preemptively construct enrichers, which are opaque to the wrapped logger.

This PR skips the preemptive enricher construction for types that are "safe" to hang onto in closures, including the strings ultimately used for `SourceContext`.

Fixes #42 .