### PR TITLE
Add exception to IDiagnosticContext

### DIFF
--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContext.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContext.cs
@@ -56,5 +56,12 @@ namespace Serilog.Extensions.Hosting
                 collector.AddOrUpdate(property);
             }
         }
+
+        /// <inheritdoc cref="IDiagnosticContext.SetException"/>
+        public void SetException(Exception exception)
+        {
+            var collector = AmbientDiagnosticContextCollector.Current;
+            collector?.SetException(exception);
+        }
     }
 }

--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContextCollector.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContextCollector.cs
@@ -68,6 +68,7 @@ namespace Serilog.Extensions.Hosting
         /// </summary>
         /// <param name="properties">The collected properties, or null if no collection is active.</param>
         /// <returns>True if properties could be collected.</returns>
+        /// <seealso cref="IDiagnosticContext.Set"/>
         public bool TryComplete(out IEnumerable<LogEventProperty> properties)
         {
             lock (_propertiesLock)
@@ -81,21 +82,15 @@ namespace Serilog.Extensions.Hosting
         }
 
         /// <summary>
-        /// Complete the context and retrieve the properties added to it, if any. This will
+        /// Complete the context and retrieve the properties and exception added to it, if any. This will
         /// stop collection and remove the collector from the original execution context and
         /// any of its children.
         /// </summary>
         /// <param name="properties">The collected properties, or null if no collection is active.</param>
         /// <param name="exception">The collected exception, or null if none has been collected or if no collection is active.</param>
         /// <returns>True if properties could be collected.</returns>
-        /// <example>
-        /// This overload provides the exception collected by the diagnostic context, which is useful when unhandled exceptions are handled
-        /// before reaching Serilog's RequestLoggingMiddleware. One example is using https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails to transform
-        /// exceptions to ProblemDetails responses.
-        /// </example>
-        /// <remarks>
-        /// If an unhandled exception reaches Serilog's RequestLoggingMiddleware, then the unhandled exception should take precedence.<br/>
-        /// </remarks>
+        /// <seealso cref="IDiagnosticContext.Set"/>
+        /// <seealso cref="Serilog.IDiagnosticContext.SetException"/>
         public bool TryComplete(out IEnumerable<LogEventProperty> properties, out Exception exception)
         {
             lock (_propertiesLock)

--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContextCollector.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContextCollector.cs
@@ -71,14 +71,7 @@ namespace Serilog.Extensions.Hosting
         /// <seealso cref="IDiagnosticContext.Set"/>
         public bool TryComplete(out IEnumerable<LogEventProperty> properties)
         {
-            lock (_propertiesLock)
-            {
-                properties = _properties?.Values;
-                _properties = null;
-                _exception = null;
-                Dispose();
-                return properties != null;
-            }
+            return TryComplete(out properties, out _);
         }
 
         /// <summary>

--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContextCollector.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContextCollector.cs
@@ -40,7 +40,7 @@ namespace Serilog.Extensions.Hosting
         }
 
         /// <summary>
-        /// Set an exception to include in the Serilog request log event.
+        /// Set the exception associated with the current diagnostic context.
         /// </summary>
         /// <example>
         /// Passing an exception to the diagnostic context is useful when unhandled exceptions are handled before reaching Serilog's
@@ -69,6 +69,7 @@ namespace Serilog.Extensions.Hosting
         /// <param name="properties">The collected properties, or null if no collection is active.</param>
         /// <returns>True if properties could be collected.</returns>
         /// <seealso cref="IDiagnosticContext.Set"/>
+        [Obsolete("Replaced by TryComplete(out IEnumerable<LogEventProperty> properties, out Exception exception).")]
         public bool TryComplete(out IEnumerable<LogEventProperty> properties)
         {
             return TryComplete(out properties, out _);

--- a/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
+++ b/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
@@ -32,15 +32,13 @@ namespace Serilog
         void Set(string propertyName, object value, bool destructureObjects = false);
 
         /// <summary>
-        /// Set an exception to include in the Serilog request log event.
+        /// Set the specified exception on the current diagnostic context.
+        /// <br/><br/>
+        /// This is useful when unhandled exceptions do not reach Serilog.AspNetCore's RequestLoggingMiddleware,
+        /// such as when using <a href="https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails">Hellang.Middleware.ProblemDetails</a>
+        /// to transform exceptions to ProblemDetails responses.
         /// </summary>
-        /// <example>
-        /// Passing an exception to the diagnostic context is useful when unhandled exceptions are handled before reaching Serilog's
-        /// RequestLoggingMiddleware. One example is using https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails to transform
-        /// exceptions to ProblemDetails responses.
-        /// </example>
         /// <remarks>
-        /// If an unhandled exception reaches Serilog's RequestLoggingMiddleware, then the unhandled exception takes precedence.<br/>
         /// If <c>null</c> is given, it clears any previously assigned exception.
         /// </remarks>
         /// <param name="exception">The exception to log.</param>

--- a/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
+++ b/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
@@ -33,15 +33,13 @@ namespace Serilog
 
         /// <summary>
         /// Set the specified exception on the current diagnostic context.
-        /// <br/><br/>
-        /// This is useful when unhandled exceptions do not reach <c>Serilog.AspNetCore.RequestLoggingMiddleware</c>,
-        /// such as when using <a href="https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails">Hellang.Middleware.ProblemDetails</a>
-        /// to transform exceptions to ProblemDetails responses.
         /// </summary>
         /// <remarks>
-        /// If <c>null</c> is given, it clears any previously assigned exception.
+        /// This method is useful when unhandled exceptions do not reach <c>Serilog.AspNetCore.RequestLoggingMiddleware</c>,
+        /// such as when using <a href="https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails">Hellang.Middleware.ProblemDetails</a>
+        /// to transform exceptions to ProblemDetails responses.
         /// </remarks>
-        /// <param name="exception">The exception to log.</param>
+        /// <param name="exception">The exception to log. If <c>null</c> is given, it clears any previously assigned exception.</param>
         void SetException(Exception exception);
     }
 }

--- a/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
+++ b/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+using System;
+
 namespace Serilog
 {
     /// <summary>
@@ -27,6 +29,21 @@ namespace Serilog
         /// <param name="value">The property value.</param>
         /// <param name="destructureObjects">If true, the value will be serialized as structured
         /// data if possible; if false, the object will be recorded as a scalar or simple array.</param>
-        void Set(string propertyName, object value, bool destructureObjects = false); 
+        void Set(string propertyName, object value, bool destructureObjects = false);
+
+        /// <summary>
+        /// Set an exception to include in the Serilog request log event.
+        /// </summary>
+        /// <example>
+        /// Passing an exception to the diagnostic context is useful when unhandled exceptions are handled before reaching Serilog's
+        /// RequestLoggingMiddleware. One example is using https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails to transform
+        /// exceptions to ProblemDetails responses.
+        /// </example>
+        /// <remarks>
+        /// If an unhandled exception reaches Serilog's RequestLoggingMiddleware, then the unhandled exception takes precedence.<br/>
+        /// If <c>null</c> is given, it clears any previously assigned exception.
+        /// </remarks>
+        /// <param name="exception">The exception to log.</param>
+        void SetException(Exception exception);
     }
 }

--- a/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
+++ b/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
@@ -34,7 +34,7 @@ namespace Serilog
         /// <summary>
         /// Set the specified exception on the current diagnostic context.
         /// <br/><br/>
-        /// This is useful when unhandled exceptions do not reach Serilog.AspNetCore's RequestLoggingMiddleware,
+        /// This is useful when unhandled exceptions do not reach <c>Serilog.AspNetCore.RequestLoggingMiddleware</c>,
         /// such as when using <a href="https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails">Hellang.Middleware.ProblemDetails</a>
         /// to transform exceptions to ProblemDetails responses.
         /// </summary>

--- a/test/Serilog.Extensions.Hosting.Tests/DiagnosticContextTests.cs
+++ b/test/Serilog.Extensions.Hosting.Tests/DiagnosticContextTests.cs
@@ -19,6 +19,13 @@ namespace Serilog.Extensions.Hosting.Tests
         }
 
         [Fact]
+        public void SetExceptionIsSafeWhenNoContextIsActive()
+        {
+            var dc = new DiagnosticContext(Some.Logger());
+            dc.SetException(new Exception("test"));
+        }
+
+        [Fact]
         public async Task PropertiesAreCollectedInAnActiveContext()
         {
             var dc = new DiagnosticContext(Some.Logger());
@@ -40,6 +47,48 @@ namespace Serilog.Extensions.Hosting.Tests
         }
 
         [Fact]
+        public void ExceptionIsCollectedInAnActiveContext()
+        {
+            var dc = new DiagnosticContext(Some.Logger());
+            var collector = dc.BeginCollection();
+
+            var setException = new Exception("before collect");
+            dc.SetException(setException);
+
+            Assert.True(collector.TryComplete(out _, out var collectedException));
+            Assert.Same(setException, collectedException);
+        }
+
+        [Fact]
+        public void ExceptionIsNotCollectedAfterTryComplete()
+        {
+            var dc = new DiagnosticContext(Some.Logger());
+            var collector = dc.BeginCollection();
+            collector.TryComplete(out _, out _);
+            dc.SetException(new Exception(Some.String("after collect")));
+
+            var tryComplete2 = collector.TryComplete(out _, out var collectedException2);
+
+            Assert.False(tryComplete2);
+            Assert.Null(collectedException2);
+        }
+
+        [Fact]
+        public void ExceptionIsNotCollectedAfterDispose()
+        {
+            var dc = new DiagnosticContext(Some.Logger());
+            var collector = dc.BeginCollection();
+            collector.Dispose();
+
+            dc.SetException(new Exception("after dispose"));
+
+            var tryComplete = collector.TryComplete(out _, out var collectedException);
+
+            Assert.True(tryComplete);
+            Assert.Null(collectedException);
+        }
+
+        [Fact]
         public void ExistingPropertiesCanBeUpdated()
         {
             var dc = new DiagnosticContext(Some.Logger());
@@ -52,6 +101,19 @@ namespace Serilog.Extensions.Hosting.Tests
             var prop = Assert.Single(properties);
             var scalar = Assert.IsType<ScalarValue>(prop.Value);
             Assert.Equal(20, scalar.Value);
+        }
+
+        [Fact]
+        public void ExistingExceptionCanBeUpdated()
+        {
+            var dc = new DiagnosticContext(Some.Logger());
+            var collector = dc.BeginCollection();
+
+            dc.SetException(new Exception("ex1"));
+            dc.SetException(new Exception("ex2"));
+
+            Assert.True(collector.TryComplete(out _, out var collectedException));
+            Assert.Equal("ex2", collectedException.Message);
         }
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/serilog/serilog-aspnetcore/issues/270
Related PR: https://github.com/serilog/serilog-aspnetcore/pull/271

For applications using middleware like [Hellang.Middleware.ProblemDetails](https://www.nuget.org/packages/Hellang.Middleware.ProblemDetails/), where unhandled exceptions are swallowed, the application can pass on the exception to Serilog.AspNetCore's `RequestLoggingMiddleware` via `IDiagnosticContext`.

### Changes
- Add `IDiagnosticContext.SetException(Exception e)`
- Add new overload `DiagnosticContextCollector.TryComplete(out IEnumerable<LogEventProperty>, out Exception)` to not make a breaking change.
- Add tests on setting and collecting the exception.