### PR TITLE
Add .NET 6 to other target frameworks, add conditions based on TFM for Nuget packages.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: '{build}'
 skip_tags: true
-image: Visual Studio 2019
+image: Visual Studio 2022
 test: off
 build_script:
 - ps: ./Build.ps1

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
     "allowPrerelease": false,
-    "version": "5.0.102",
+    "version": "6.0.100",
     "rollForward": "latestFeature"
   }
 }

--- a/samples/SimpleServiceSample/SimpleServiceSample.csproj
+++ b/samples/SimpleServiceSample/SimpleServiceSample.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
-  
-  <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
-  </PropertyGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
-  </ItemGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-  </ItemGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
+
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+	</ItemGroup>
 
 </Project>

--- a/samples/SimpleServiceSample/SimpleServiceSample.csproj
+++ b/samples/SimpleServiceSample/SimpleServiceSample.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
   
   <PropertyGroup>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   
   <ItemGroup>
@@ -9,9 +9,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="3.1.4" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
-    <PackageReference Include="Serilog.Settings.Configuration" Version="3.1.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
   </ItemGroup>
 
 </Project>

--- a/samples/SimpleServiceSample/SimpleServiceSample.csproj
+++ b/samples/SimpleServiceSample/SimpleServiceSample.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
 
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-	</ItemGroup>
+  <PropertyGroup>
+  	<TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+  	<ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+  	<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+  </ItemGroup>
 
 </Project>

--- a/samples/SimpleServiceSample/SimpleServiceSample.csproj
+++ b/samples/SimpleServiceSample/SimpleServiceSample.csproj
@@ -1,5 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
-
+<Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
   	<TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>

--- a/samples/WebApplicationSample/WebApplicationSample.csproj
+++ b/samples/WebApplicationSample/WebApplicationSample.csproj
@@ -1,17 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-	<PropertyGroup>
-		<TargetFramework>net6.0</TargetFramework>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-	</ItemGroup>
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+  </PropertyGroup>
+  
+  <ItemGroup>
+  	<ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+  	<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+  	<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+  </ItemGroup>
 
 </Project>

--- a/samples/WebApplicationSample/WebApplicationSample.csproj
+++ b/samples/WebApplicationSample/WebApplicationSample.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>netcoreapp3.1</TargetFramework>
+        <TargetFramework>net6.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>
@@ -9,9 +9,9 @@
     </ItemGroup>
 
     <ItemGroup>
-      <PackageReference Include="serilog.settings.configuration" Version="3.1.0" />
-      <PackageReference Include="serilog.sinks.console" Version="3.1.1" />
-      <PackageReference Include="serilog.sinks.file" Version="4.1.0" />
+      <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+	  <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+	  <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
     </ItemGroup>
 
 </Project>

--- a/samples/WebApplicationSample/WebApplicationSample.csproj
+++ b/samples/WebApplicationSample/WebApplicationSample.csproj
@@ -1,17 +1,17 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
-    <PropertyGroup>
-        <TargetFramework>net6.0</TargetFramework>
-    </PropertyGroup>
+	<PropertyGroup>
+		<TargetFramework>net6.0</TargetFramework>
+	</PropertyGroup>
 
-    <ItemGroup>
-      <ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
-    </ItemGroup>
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
+	</ItemGroup>
 
-    <ItemGroup>
-      <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
-	  <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
-	  <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
-    </ItemGroup>
+	<ItemGroup>
+		<PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+		<PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+		<PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+	</ItemGroup>
 
 </Project>

--- a/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
+++ b/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
@@ -1,42 +1,56 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <Description>Serilog support for .NET Core logging in hosted services</Description>
-    <VersionPrefix>4.2.1</VersionPrefix>
-    <Authors>Microsoft;Serilog Contributors</Authors>
-    <TargetFrameworks>netstandard2.0;netstandard2.1</TargetFrameworks>
-    <LangVersion>8</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <AssemblyName>Serilog.Extensions.Hosting</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <PackageId>Serilog.Extensions.Hosting</PackageId>
-    <PackageTags>serilog;aspnet;aspnetcore;hosting</PackageTags>
-    <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/serilog/serilog-extensions-hosting</PackageProjectUrl>
-    <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-    <RepositoryUrl>https://github.com/serilog/serilog-extensions-hosting</RepositoryUrl>
-    <RepositoryType>git</RepositoryType>
-    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-    <RootNamespace>Serilog</RootNamespace>
-  </PropertyGroup>
+	<PropertyGroup>
+		<Description>Serilog support for .NET Core logging in hosted services</Description>
+		<VersionPrefix>4.2.1</VersionPrefix>
+		<Authors>Microsoft;Serilog Contributors</Authors>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+		<GenerateDocumentationFile>true</GenerateDocumentationFile>
+		<AssemblyName>Serilog.Extensions.Hosting</AssemblyName>
+		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+		<SignAssembly>true</SignAssembly>
+		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+		<PackageId>Serilog.Extensions.Hosting</PackageId>
+		<PackageTags>serilog;aspnet;aspnetcore;hosting</PackageTags>
+		<PackageIcon>icon.png</PackageIcon>
+		<PackageProjectUrl>https://github.com/serilog/serilog-extensions-hosting</PackageProjectUrl>
+		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+		<RepositoryUrl>https://github.com/serilog/serilog-extensions-hosting</RepositoryUrl>
+		<RepositoryType>git</RepositoryType>
+		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+		<RootNamespace>Serilog</RootNamespace>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-    <DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
-  </PropertyGroup>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+		<DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.8" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.8" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+	</ItemGroup>
 
-  <ItemGroup>
-    <None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
-    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-  </ItemGroup>
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+	</ItemGroup>
+
+	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR  '$(TargetFramework)' == 'netstandard2.1' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.22" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.22" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.22" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<PackageReference Include="Serilog" Version="2.10.0" />
+		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+	</ItemGroup>
+
+	<ItemGroup>
+		<None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
+		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+	</ItemGroup>
 </Project>

--- a/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
+++ b/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<Description>Serilog support for .NET Core logging in hosted services</Description>

--- a/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
+++ b/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
@@ -52,6 +52,6 @@
   
   <ItemGroup>
   	<None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
-  	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
   </ItemGroup>
 </Project>

--- a/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
+++ b/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
@@ -1,56 +1,57 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<Description>Serilog support for .NET Core logging in hosted services</Description>
-		<VersionPrefix>4.2.1</VersionPrefix>
-		<Authors>Microsoft;Serilog Contributors</Authors>
-		<TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
-		<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-		<GenerateDocumentationFile>true</GenerateDocumentationFile>
-		<AssemblyName>Serilog.Extensions.Hosting</AssemblyName>
-		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-		<SignAssembly>true</SignAssembly>
-		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-		<PackageId>Serilog.Extensions.Hosting</PackageId>
-		<PackageTags>serilog;aspnet;aspnetcore;hosting</PackageTags>
-		<PackageIcon>icon.png</PackageIcon>
-		<PackageProjectUrl>https://github.com/serilog/serilog-extensions-hosting</PackageProjectUrl>
-		<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
-		<RepositoryUrl>https://github.com/serilog/serilog-extensions-hosting</RepositoryUrl>
-		<RepositoryType>git</RepositoryType>
-		<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
-		<RootNamespace>Serilog</RootNamespace>
-	</PropertyGroup>
+  <PropertyGroup>
+	<Description>Serilog support for .NET Core logging in hosted services</Description>
+	<VersionPrefix>4.2.1</VersionPrefix>
+	<Authors>Microsoft;Serilog Contributors</Authors>
+	<TargetFrameworks>netstandard2.0;netstandard2.1;net5.0;net6.0</TargetFrameworks>
+	<LangVersion>8</LangVersion>
+	<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+	<GenerateDocumentationFile>true</GenerateDocumentationFile>
+	<AssemblyName>Serilog.Extensions.Hosting</AssemblyName>
+	<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+	<SignAssembly>true</SignAssembly>
+	<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+	<PackageId>Serilog.Extensions.Hosting</PackageId>
+	<PackageTags>serilog;aspnet;aspnetcore;hosting</PackageTags>
+	<PackageIcon>icon.png</PackageIcon>
+	<PackageProjectUrl>https://github.com/serilog/serilog-extensions-hosting</PackageProjectUrl>
+	<PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
+	<RepositoryUrl>https://github.com/serilog/serilog-extensions-hosting</RepositoryUrl>
+	<RepositoryType>git</RepositoryType>
+	<GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+	<RootNamespace>Serilog</RootNamespace>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
-		<DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
-	</PropertyGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
-	</ItemGroup>
-	
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-	</ItemGroup>
-
-	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR  '$(TargetFramework)' == 'netstandard2.1' ">
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.22" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.22" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.22" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Serilog" Version="2.10.0" />
-		<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
-	</ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
+  </PropertyGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+  	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+  	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+  	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+  	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+  	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
+  </ItemGroup>
+  
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR  '$(TargetFramework)' == 'netstandard2.1' ">
+  	<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="3.1.22" />
+  	<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="3.1.22" />
+  	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="3.1.22" />
+  </ItemGroup>
+  
+  <ItemGroup>
+  	<PackageReference Include="Serilog" Version="2.10.0" />
+  	<PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+  </ItemGroup>
+  
+  <ItemGroup>
+  	<None Include="..\..\assets\icon.png" Pack="true" Visible="false" PackagePath="" />
+  	<PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
+++ b/src/Serilog.Extensions.Hosting/Serilog.Extensions.Hosting.csproj
@@ -26,16 +26,16 @@
 		<DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
 	</PropertyGroup>
 
-	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
-		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
-	</ItemGroup>
-
 	<ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
 		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.0" />
+	</ItemGroup>
+	
+	<ItemGroup Condition=" '$(TargetFramework)' == 'net5.0' ">
+		<PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="5.0.0" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="5.0.0" />
 	</ItemGroup>
 
 	<ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' OR  '$(TargetFramework)' == 'netstandard2.1' ">

--- a/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
+++ b/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
@@ -1,35 +1,34 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFrameworks>net4.8;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-		<AssemblyName>Serilog.Extensions.Hosting.Tests</AssemblyName>
-		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-		<SignAssembly>true</SignAssembly>
-		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-		<LangVersion>latest</LangVersion>
-	</PropertyGroup>
+  <PropertyGroup>
+	<TargetFrameworks>net4.8;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+	<AssemblyName>Serilog.Extensions.Hosting.Tests</AssemblyName>
+	<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+	<SignAssembly>true</SignAssembly>
+	<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+	<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+	<LangVersion>latest</LangVersion>
+  </PropertyGroup>
 
-	<PropertyGroup Condition=" '$(TargetFramework)' == 'net4.8' ">
-		<DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
-	</PropertyGroup>
-
-	<ItemGroup>
-		<ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net4.8' " />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2"  Condition=" '$(TargetFramework)' == 'net5.0' " />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0"  Condition=" '$(TargetFramework)' == 'net6.0' " />
-
-
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-			<PrivateAssets>all</PrivateAssets>
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-		</PackageReference>
-		<PackageReference Include="xunit" Version="2.4.1" />
-	</ItemGroup>
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net4.8' ">
+    <DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net4.8' " />
+  	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2"  Condition=" '$(TargetFramework)' == 'net5.0' " />
+  	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0"  Condition=" '$(TargetFramework)' == 'net6.0' " />
+  
+  	<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+  	<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+  		<PrivateAssets>all</PrivateAssets>
+  		<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+  	</PackageReference>
+  	<PackageReference Include="xunit" Version="2.4.1" />
+  </ItemGroup>
 
 </Project>

--- a/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
+++ b/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
@@ -20,8 +20,8 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net4.8' " />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" Condition=" '$(TargetFramework)' == 'net5.0' " />
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2"  Condition=" '$(TargetFramework)' == 'net5.0' " />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0"  Condition=" '$(TargetFramework)' == 'net6.0' " />
 
 
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />

--- a/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
+++ b/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
@@ -1,35 +1,35 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-  <PropertyGroup>
-    <TargetFrameworks>net4.8;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
-    <AssemblyName>Serilog.Extensions.Hosting.Tests</AssemblyName>
-    <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
-    <SignAssembly>true</SignAssembly>
-    <PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
-    <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
-    <LangVersion>latest</LangVersion>
-  </PropertyGroup>
+	<PropertyGroup>
+		<TargetFrameworks>net4.8;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
+		<AssemblyName>Serilog.Extensions.Hosting.Tests</AssemblyName>
+		<AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
+		<SignAssembly>true</SignAssembly>
+		<PublicSign Condition=" '$(OS)' != 'Windows_NT' ">true</PublicSign>
+		<GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
+		<LangVersion>latest</LangVersion>
+	</PropertyGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net4.8' ">
-    <DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
-  </PropertyGroup>
-  
-  <ItemGroup>
-    <ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
-  </ItemGroup>
+	<PropertyGroup Condition=" '$(TargetFramework)' == 'net4.8' ">
+		<DefineConstants>$(DefineConstants);NO_RELOADABLE_LOGGER</DefineConstants>
+	</PropertyGroup>
 
-  <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net4.8' " />
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" Condition=" '$(TargetFramework)' == 'net5.0' " />  
-	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
+	<ItemGroup>
+		<ProjectReference Include="..\..\src\Serilog.Extensions.Hosting\Serilog.Extensions.Hosting.csproj" />
+	</ItemGroup>
 
-	  
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-    <PackageReference Include="xunit" Version="2.4.1" />
-  </ItemGroup>
-  
+	<ItemGroup>
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net4.8' " />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" Condition=" '$(TargetFramework)' == 'net5.0' " />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
+
+
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
+		<PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+			<PrivateAssets>all</PrivateAssets>
+			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+		</PackageReference>
+		<PackageReference Include="xunit" Version="2.4.1" />
+	</ItemGroup>
+
 </Project>

--- a/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
+++ b/test/Serilog.Extensions.Hosting.Tests/Serilog.Extensions.Hosting.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net5.0;net4.8</TargetFrameworks>
+    <TargetFrameworks>net4.8;netcoreapp3.1;net5.0;net6.0</TargetFrameworks>
     <AssemblyName>Serilog.Extensions.Hosting.Tests</AssemblyName>
     <AssemblyOriginatorKeyFile>../../assets/Serilog.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
@@ -19,7 +19,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.4" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="3.1.22" Condition=" '$(TargetFramework)' == 'netcoreapp3.1' OR '$(TargetFramework)' == 'net4.8' " />
+	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.2" Condition=" '$(TargetFramework)' == 'net5.0' " />  
+	<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" Condition=" '$(TargetFramework)' == 'net6.0' " />
+
+	  
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
Hello dear Nicholas.
This pull request adds .NET6 to other TFMs and use conditions for installing dependencies.
I Bumped TFM of sample projects to .NET 6.
Everything is okay.
<img width="890" alt="image" src="https://user-images.githubusercontent.com/68565441/146449170-34af241b-3286-459a-96a1-3ca128e530bc.png">
