### PR TITLE
Fix nullability for DiagnosticContext.Set

### DIFF
--- a/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContext.cs
+++ b/src/Serilog.Extensions.Hosting/Extensions/Hosting/DiagnosticContext.cs
@@ -45,7 +45,7 @@ public sealed class DiagnosticContext : IDiagnosticContext
     }
 
     /// <inheritdoc cref="IDiagnosticContext.Set"/>
-    public void Set(string propertyName, object value, bool destructureObjects = false)
+    public void Set(string propertyName, object? value, bool destructureObjects = false)
     {
         if (propertyName == null) throw new ArgumentNullException(nameof(propertyName));
 

--- a/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
+++ b/src/Serilog.Extensions.Hosting/IDiagnosticContext.cs
@@ -29,7 +29,7 @@ public interface IDiagnosticContext
     /// <param name="value">The property value.</param>
     /// <param name="destructureObjects">If true, the value will be serialized as structured
     /// data if possible; if false, the object will be recorded as a scalar or simple array.</param>
-    void Set(string propertyName, object value, bool destructureObjects = false);
+    void Set(string propertyName, object? value, bool destructureObjects = false);
 
     /// <summary>
     /// Set the specified exception on the current diagnostic context.


### PR DESCRIPTION
DiagnosticContext actually accepts nulls as values, and it have a perfect sense (property exists, but it is null)